### PR TITLE
Allow signatureVersion for eu-central-1 uploads

### DIFF
--- a/tasks/aws_s3.js
+++ b/tasks/aws_s3.js
@@ -222,7 +222,7 @@ module.exports = function (grunt) {
 		}
 
 		// Allow additional (not required) options
-		_.extend(s3_options, _.pick(options, ['maxRetries', 'sslEnabled', 'httpOptions']));
+		_.extend(s3_options, _.pick(options, ['maxRetries', 'sslEnabled', 'httpOptions', 'signatureVersion']));
 
 		var s3 = new AWS.S3(s3_options);
 


### PR DESCRIPTION
eu-central-1 requires signatureVersion 4, this change would allow configuring aws to use the correct signing mechanism.